### PR TITLE
Heinz string suggestions

### DIFF
--- a/brain.txt
+++ b/brain.txt
@@ -1,4 +1,4 @@
-clear; mvn clean install; java -Xms2g -Xmx2g -XX:+AlwaysPreTouch -jar target/benchmarks.jar StackVsHeap -prof gc
+clear; mvn clean verify; java -Xms2g -Xmx2g -XX:+AlwaysPreTouch -jar target/benchmarks.jar StackVsHeap -prof gc
 
 # -XX:+PrintGCDetails
 # -XX:+PrintGCDateStamps

--- a/src/main/java/org/sample/Strings1.java
+++ b/src/main/java/org/sample/Strings1.java
@@ -16,57 +16,53 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 2, time = 2, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 2, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
-@Fork(1)
-public class Strings1
-{
+@Warmup(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+public class Strings1 {
+    private static final String PREFIX = "a";
     private String foo = null;
-    
+    private int LENGTH;
+
     @Setup
-    public void setup()
-    {
+    public void setup() {
+        //                        13 chars                  18 chars
         foo = String.valueOf(System.currentTimeMillis()) + "ashdfhgas dfhsa df";
-    }
-    
-    @Benchmark
-    public String plain()
-    {    
-        return "a" + foo;
+        LENGTH = plain().length();
     }
 
     @Benchmark
-    public String concat()
-    {    
-        return "a".concat(foo);
+    public String plain() {
+        return PREFIX + foo;
     }
 
     @Benchmark
-    public String builder()
-    {    
-        return new StringBuilder().append("a").append(foo).toString();
+    public String concat() {
+        return PREFIX.concat(foo);
     }
 
     @Benchmark
-    public String builderSized()
-    {    
-        return new StringBuilder(70).append("a").append(foo).toString();
+    public String builder() {
+        return new StringBuilder().append(PREFIX).append(foo).toString();
     }
-    
+
     @Benchmark
-    public String builderNonFluid()
-    {    
-         final StringBuilder sb = new StringBuilder();
-         sb.append("a");
-         sb.append(foo);
-         return sb.toString();
+    public String builderSized() {
+        return new StringBuilder(LENGTH).append(PREFIX).append(foo).toString();
     }
-    
+
     @Benchmark
-    public String builderNonFluidSized()
-    {    
-        final StringBuilder sb = new StringBuilder(70);
-        sb.append("a");
+    public String builderNonFluid() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(PREFIX);
+        sb.append(foo);
+        return sb.toString();
+    }
+
+    @Benchmark
+    public String builderNonFluidSized() {
+        final StringBuilder sb = new StringBuilder(LENGTH);
+        sb.append(PREFIX);
         sb.append(foo);
         return sb.toString();
     }

--- a/src/main/java/org/sample/Strings1.java
+++ b/src/main/java/org/sample/Strings1.java
@@ -16,8 +16,8 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 30, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
 @Fork(3)
 public class Strings1 {
     private static final String PREFIX = "a";

--- a/src/main/java/org/sample/StringsMixed.java
+++ b/src/main/java/org/sample/StringsMixed.java
@@ -1,0 +1,118 @@
+package org.sample;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 30, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+public class StringsMixed {
+    private static final String PREFIX = "a";
+    private static final String SEPARATOR = ";";
+    private static final String FORMAT =
+            PREFIX + "%d" + SEPARATOR + "%s" + SEPARATOR + "%b";
+    private long time;
+    private double nanoTime;
+    private int LENGTH;
+    private boolean oddTime;
+
+    @Setup
+    public void setup() {
+        time = System.currentTimeMillis();
+        nanoTime = System.nanoTime();
+        oddTime = time % 2 == 1;
+        String expected = plain();
+        LENGTH = expected.length();
+        for (Method method : StringsMixed.class.getDeclaredMethods()) {
+            if (method.getReturnType() == String.class
+                    && method.getParameterCount() == 0) {
+                try {
+                    String result = (String) method.invoke(this);
+                    if (!result.equals(expected)) {
+                        throw new AssertionError(String.format(
+                                "Expected \"%s\", but got \"%s\" from method %s()",
+                                expected, result, method.getName()));
+                    }
+                } catch (ReflectiveOperationException e) {
+                    throw new AssertionError(e);
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public String plain() {
+        return PREFIX + time + SEPARATOR + nanoTime + SEPARATOR + oddTime;
+    }
+
+    @Benchmark
+    public String concat() {
+        return PREFIX.concat("" + time).concat(SEPARATOR).concat("" + nanoTime)
+                .concat(SEPARATOR).concat("" + oddTime);
+    }
+
+    @Benchmark
+    public String builder() {
+        return new StringBuilder().append(PREFIX)
+                .append(time)
+                .append(SEPARATOR)
+                .append(nanoTime)
+                .append(SEPARATOR)
+                .append(oddTime)
+                .toString();
+    }
+
+    @Benchmark
+    public String builderSized() {
+        return new StringBuilder(LENGTH).append(PREFIX)
+                .append(time)
+                .append(SEPARATOR)
+                .append(nanoTime)
+                .append(SEPARATOR)
+                .append(oddTime)
+                .toString();
+    }
+
+    @Benchmark
+    public String builderNonFluid() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(PREFIX);
+        sb.append(time);
+        sb.append(SEPARATOR);
+        sb.append(nanoTime);
+        sb.append(SEPARATOR);
+        sb.append(oddTime);
+        return sb.toString();
+    }
+
+    @Benchmark
+    public String builderNonFluidSized() {
+        StringBuilder sb = new StringBuilder(LENGTH);
+        sb.append(PREFIX);
+        sb.append(time);
+        sb.append(SEPARATOR);
+        sb.append(nanoTime);
+        sb.append(SEPARATOR);
+        sb.append(oddTime);
+        return sb.toString();
+    }
+
+    @Benchmark
+    public String format() {
+        return String.format(FORMAT, time, nanoTime, oddTime);
+    }
+}


### PR DESCRIPTION
Results from running on my server are attached.

Java 11:
```
Benchmark                          Mode  Cnt    Score   Error  Units
Strings1.builder                   avgt   30   12.580 ± 0.034  ns/op
Strings1.builderNonFluid           avgt   30   23.460 ± 0.071  ns/op
Strings1.builderNonFluidSized      avgt   30   17.281 ± 0.101  ns/op
Strings1.builderSized              avgt   30   12.634 ± 0.124  ns/op
Strings1.concat                    avgt   30   16.038 ± 0.037  ns/op
Strings1.plain                     avgt   30   13.641 ± 0.029  ns/op
StringsMixed.builder               avgt   30  116.168 ± 4.528  ns/op
StringsMixed.builderNonFluid       avgt   30  121.871 ± 3.334  ns/op
StringsMixed.builderNonFluidSized  avgt   30   99.973 ± 8.118  ns/op
StringsMixed.builderSized          avgt   30   92.057 ± 4.093  ns/op
StringsMixed.concat                avgt   30  112.961 ± 4.216  ns/op
StringsMixed.format                avgt   30  879.149 ± 9.985  ns/op
StringsMixed.plain                 avgt   30   68.883 ± 4.331  ns/op
```

Java 17
```
Benchmark                          Mode  Cnt    Score   Error  Units
Strings1.builder                   avgt   30   10.834 ± 0.040  ns/op
Strings1.builderNonFluid           avgt   30   24.389 ± 0.153  ns/op
Strings1.builderNonFluidSized      avgt   30   15.338 ± 0.312  ns/op
Strings1.builderSized              avgt   30   10.927 ± 0.040  ns/op
Strings1.concat                    avgt   30   12.185 ± 0.190  ns/op
Strings1.plain                     avgt   30   12.965 ± 0.116  ns/op
StringsMixed.builder               avgt   30  105.416 ± 5.527  ns/op
StringsMixed.builderNonFluid       avgt   30  118.847 ± 1.694  ns/op
StringsMixed.builderNonFluidSized  avgt   30   86.668 ± 3.988  ns/op
StringsMixed.builderSized          avgt   30   83.685 ± 4.579  ns/op
StringsMixed.concat                avgt   30   99.556 ± 6.213  ns/op
StringsMixed.format                avgt   30  524.932 ± 5.821  ns/op
StringsMixed.plain                 avgt   30   62.380 ± 1.017  ns/op
```

Interesting how much better Java 17 is than Java 11. I ran the benchmark for a very long time to make sure that I wasn't seeing ghosts. I understand that this is impractical in a training setting.

[Strings-results-heinz-java11.txt](https://github.com/Xceptance/jmh-jmm-training/files/8102486/Strings-results-heinz-java11.txt)
[Strings-results-heinz-java17.txt](https://github.com/Xceptance/jmh-jmm-training/files/8102487/Strings-results-heinz-java17.txt)
